### PR TITLE
Refactor Certificates and TLS options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use Certificate resource instead of cert-manager annotation.
+- Allow multiple certificateRefs in listener for custom Certificates.
+- Allow subdomains in HTTPS listener.
+- Support multiple dnsNames in Certificate CR.
+
 ## [0.1.0] - 2025-02-05
 
 - changed: `app.giantswarm.io` label group was changed to `application.giantswarm.io`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow multiple certificateRefs in listener for custom Certificates.
 - Allow subdomains in HTTPS listener.
 - Support multiple dnsNames in Certificate CR.
+- Rename gateway and class to `default` in Values schema.
 
 ## [0.1.0] - 2025-02-05
 

--- a/helm/gateway-api-config/templates/certificate.yaml
+++ b/helm/gateway-api-config/templates/certificate.yaml
@@ -1,0 +1,29 @@
+{{- range $i, $gateway := .Values.gateways }}
+{{- if $gateway.enabled }}
+{{- if $gateway.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-{{ $gateway.name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  dnsNames:
+  - {{ $gateway.dnsName }}.{{ $.Values.baseDomain }}
+  {{- with $gateway.certificate.dnsNames }}
+  {{- toYaml . | nindent 2}}
+  {{- end }}
+  {{- if $gateway.tlsIssuer.enabled }}
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: {{ $gateway.tlsIssuer.name }}
+  {{- else }}
+  issuerRef:
+    group: cert-manager.io
+    kind: {{ $gateway.certificate.issuer.kind }}
+    name: {{ $gateway.certificate.issuer.name }}
+  {{- end }}
+  secretName: gateway-{{ $gateway.name }}-tls
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/gateway-api-config/templates/gateway.yaml
+++ b/helm/gateway-api-config/templates/gateway.yaml
@@ -54,10 +54,15 @@ spec:
       {{- with .tls }}
       tls:
         mode: {{ .mode }}
-        {{- with .certSecretName }}
+        {{- if and (eq .mode "Terminate") ($gateway.certificate.enabled) }}
         certificateRefs:
         - kind: Secret
-          name: {{ default (printf "le-%s" $gateway.name) . }}
+          name: gateway-{{ $gateway.name }}-tls
+        {{- end }}
+        {{- with .certificateRefs }}
+        - kind: Secret
+          name: {{ .name }}
+          namespace: {{ .namespace }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/helm/gateway-api-config/templates/gateway.yaml
+++ b/helm/gateway-api-config/templates/gateway.yaml
@@ -48,7 +48,9 @@ spec:
       allowedRoutes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostname: {{ with .hostname }}{{ tpl . $ }}{{- end }}
+      {{- with .hostname }}
+      hostname: {{ tpl (. | quote) $ }}
+      {{- end }}
       {{- with .tls }}
       tls:
         mode: {{ .mode }}

--- a/helm/gateway-api-config/templates/gateway.yaml
+++ b/helm/gateway-api-config/templates/gateway.yaml
@@ -27,14 +27,9 @@ metadata:
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if or $gateway.annotations $gateway.tlsIssuer }}
+  {{- with $gateway.annotations }}
   annotations:
-    {{- if $gateway.tlsIssuer.enabled }}
-    cert-manager.io/issuer: {{ .issuer }}
-    {{- end }}
-    {{- with $gateway.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   gatewayClassName: {{ $gateway.className }}

--- a/helm/gateway-api-config/templates/gateway.yaml
+++ b/helm/gateway-api-config/templates/gateway.yaml
@@ -40,18 +40,18 @@ spec:
       name: gateway-{{ $gateway.name }}
       namespace: {{ $.Release.Namespace }}
   listeners:
-    {{- range $gateway.listeners }}
-    - name: {{ .name }}
-      protocol: {{ .protocol }}
-      port: {{ .port }}
-      {{- with .allowedRoutes }}
+    {{- range $k, $l:= $gateway.listeners }}
+    - name: {{ $l.name }}
+      protocol: {{ $l.protocol }}
+      port: {{ $l.port }}
+      {{- with $l.allowedRoutes }}
       allowedRoutes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .hostname }}
+      {{- with $l.hostname }}
       hostname: {{ tpl (. | quote) $ }}
       {{- end }}
-      {{- with .tls }}
+      {{- with $l.tls }}
       tls:
         mode: {{ .mode }}
         {{- if and (eq .mode "Terminate") ($gateway.certificate.enabled) }}
@@ -59,7 +59,7 @@ spec:
         - kind: Secret
           name: gateway-{{ $gateway.name }}-tls
         {{- end }}
-        {{- with .certificateRefs }}
+        {{- range .certificateRefs }}
         - kind: Secret
           name: {{ .name }}
           namespace: {{ .namespace }}

--- a/helm/gateway-api-config/values.schema.json
+++ b/helm/gateway-api-config/values.schema.json
@@ -8,7 +8,7 @@
         "gatewayClasses": {
             "type": "object",
             "properties": {
-                "giantswarm-default": {
+                "default": {
                     "type": "object",
                     "properties": {
                         "enabled": {
@@ -24,7 +24,7 @@
         "gateways": {
             "type": "object",
             "properties": {
-                "giantswarm-default": {
+                "default": {
                     "type": "object",
                     "properties": {
                         "certificate": {

--- a/helm/gateway-api-config/values.schema.json
+++ b/helm/gateway-api-config/values.schema.json
@@ -48,31 +48,71 @@
                             "type": "boolean"
                         },
                         "listeners": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "allowedRoutes": {
-                                        "type": "object",
-                                        "properties": {
-                                            "namespaces": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "from": {
-                                                        "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "object",
+                                    "properties": {
+                                        "allowedRoutes": {
+                                            "type": "object",
+                                            "properties": {
+                                                "namespaces": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "from": {
+                                                            "type": "string"
+                                                        }
                                                     }
                                                 }
                                             }
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
                                         }
-                                    },
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "port": {
-                                        "type": "integer"
-                                    },
-                                    "protocol": {
-                                        "type": "string"
+                                    }
+                                },
+                                "https": {
+                                    "type": "object",
+                                    "properties": {
+                                        "allowedRoutes": {
+                                            "type": "object",
+                                            "properties": {
+                                                "namespaces": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "from": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "hostname": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        },
+                                        "protocol": {
+                                            "type": "string"
+                                        },
+                                        "tls": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mode": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/helm/gateway-api-config/values.schema.json
+++ b/helm/gateway-api-config/values.schema.json
@@ -30,6 +30,9 @@
                         "certificate": {
                             "type": "object",
                             "properties": {
+                                "dnsNames": {
+                                    "type": "array"
+                                },
                                 "enabled": {
                                     "type": "boolean"
                                 }

--- a/helm/gateway-api-config/values.schema.json
+++ b/helm/gateway-api-config/values.schema.json
@@ -16,9 +16,6 @@
                         },
                         "name": {
                             "type": "string"
-                        },
-                        "overrideExternalDnsHostname": {
-                            "type": "string"
                         }
                     }
                 }
@@ -30,7 +27,18 @@
                 "giantswarm-default": {
                     "type": "object",
                     "properties": {
+                        "certificate": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
                         "className": {
+                            "type": "string"
+                        },
+                        "dnsName": {
                             "type": "string"
                         },
                         "enabled": {

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -9,6 +9,7 @@ gateways:
   giantswarm-default:
     enabled: true
     name: giantswarm-default
+    dnsName: gateway
     className: giantswarm-default
     service:
       annotations:
@@ -19,6 +20,8 @@ gateways:
       name: letsencrypt-giantswarm-gateway
       email: accounts@giantswarm.io
       gateway: giantswarm-default
+    certificate:
+      enabled: true
     listeners:
     - name: http
       protocol: HTTP

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -24,18 +24,21 @@ gateways:
       enabled: true
       dnsNames: []
     listeners:
-    - name: http
-      protocol: HTTP
-      port: 80
-      allowedRoutes:
-        namespaces:
-          from: All
-    - name: https
-      protocol: HTTPS
-      hostname: '*.{{ $.Values.baseDomain }}'
-      port: 443
-      allowedRoutes:
-        namespaces:
-          from: All
-      tls:
-        mode: Terminate
+      http:
+        name: http
+        protocol: HTTP
+        port: 80
+        allowedRoutes:
+          namespaces:
+            from: All
+      https:
+        name: https
+        protocol: HTTPS
+        hostname: '*.{{ $.Values.baseDomain }}'
+        port: 443
+        allowedRoutes:
+          namespaces:
+            from: All
+        tls:
+          mode: Terminate
+          certiicateRefs: []

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -31,7 +31,7 @@ gateways:
           from: All
     - name: https
       protocol: HTTPS
-      hostname: example.{{ $.Values.baseDomain }}
+      hostname: '*.{{ $.Values.baseDomain }}'
       port: 443
       allowedRoutes:
         namespaces:

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -38,4 +38,3 @@ gateways:
           from: All
       tls:
         mode: Terminate
-        certSecretName: giantswarm-default-tls

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -22,6 +22,7 @@ gateways:
       gateway: giantswarm-default
     certificate:
       enabled: true
+      dnsNames: []
     listeners:
     - name: http
       protocol: HTTP

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -1,12 +1,12 @@
 baseDomain: example.com
 
 gatewayClasses:
-  giantswarm-default:
+  default:
     enabled: true
     name: giantswarm-default
 
 gateways:
-  giantswarm-default:
+  default:
     enabled: true
     name: giantswarm-default
     dnsName: gateway


### PR DESCRIPTION
This PR:

- remove cert manager annotation
- allow empty hostname field
- add Certificate resource for default hostname
- use main certificate and allow for multiple extra cert refs
- Allow subdomains
- update changelog

Towards https://github.com/giantswarm/giantswarm/issues/30161

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
