### PR TITLE
Fix wildcard certificate DNS name generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove infrastructure ref in GatewayClass when EnvoyProxy is disabled.
+- Fix wildcard certificate DNS name: when `certificate.wildcard: true`, emit `*.{baseDomain}` instead of the raw listener hostname.
 
 ## [1.10.0] - 2026-04-08
 

--- a/helm/gateway-api-config/templates/gateway/certificate.yaml
+++ b/helm/gateway-api-config/templates/gateway/certificate.yaml
@@ -13,11 +13,15 @@ metadata:
 spec:
   dnsNames:
   {{- $baseDomain := (trimPrefix "*." (tpl ($gateway.overrideBaseDomain | default $listener.hostname) $)) -}}
-  {{- if or (not (hasPrefix "*." $listener.hostname)) $listener.certificate.wildcard }}
+  {{- if $listener.certificate.wildcard }}
+  - {{ printf "*.%s" $baseDomain | quote }}
+  {{- else }}
+  {{- if and (not (hasPrefix "*." $listener.hostname)) ($listener.hostname) }}
   - {{ tpl $listener.hostname $ | quote }}
   {{- else }}
   {{- if eq $baseDomain $.Values.baseDomain }}
   - {{ printf "%s.%s" $gateway.dnsName $baseDomain | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- range $k, $v := $listener.subdomains }}


### PR DESCRIPTION
When certificate.wildcard is true, emit *.baseDomain instead of falling
through to the raw listener hostname.

- This way, if the $listener.certificate.wildcard is set, we only generate the cert with the wildcard. Subdomains are still being generated as before.
- if wildcard is disabled, we rely on the previous logic.
 
I tested this in a few setups and works fine. I'm wondering if we could add some CI values checks with common use-cases.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
