### PR TITLE
feat(envoyproxy): use mergeType StrategicMerge for gateway EnvoyProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `mergeType: StrategicMerge` on the gateway-level `EnvoyProxy` so it inherits the GatewayClass-level base defaults (HPA, PDB, image) instead of replacing them. Base defaults are no longer duplicated on the gateway-level `EnvoyProxy`; it now carries only gateway-specific config (`envoyService`, `shutdown`) plus user overrides. `mergeType` is configurable per gateway and per GatewayClass via `envoyProxy.mergeType`.
+
 ## [1.10.1] - 2026-05-05
 
 ### Fixed

--- a/helm/gateway-api-config/README.md
+++ b/helm/gateway-api-config/README.md
@@ -1,6 +1,6 @@
 # gateway-api-config
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=flat-square)
 
 Default configuration for Envoy Gateway
 
@@ -18,6 +18,7 @@ Default configuration for Envoy Gateway
 | gatewayClasses.default.envoyProxy.envoyPDB | object | `{}` |  |
 | gatewayClasses.default.envoyProxy.envoyService | object | `{}` |  |
 | gatewayClasses.default.envoyProxy.envoyServiceAccount | object | `{}` |  |
+| gatewayClasses.default.envoyProxy.mergeType | string | `""` |  |
 | gatewayClasses.default.errorPages.body | string | `""` |  |
 | gatewayClasses.default.errorPages.contentType | string | `"text/html"` |  |
 | gatewayClasses.default.errorPages.enabled | bool | `false` |  |
@@ -34,6 +35,9 @@ Default configuration for Envoy Gateway
 | gatewayClasses.default.errorPages.statusCodes[4].type | string | `"Value"` |  |
 | gatewayClasses.default.errorPages.statusCodes[4].value | int | `504` |  |
 | gatewayClasses.default.name | string | `"giantswarm-default"` |  |
+| gateways.default.allowedListeners.enabled | bool | `false` |  |
+| gateways.default.allowedListeners.namespaces.from | string | `"All"` |  |
+| gateways.default.allowedListeners.namespaces.selector | object | `{}` |  |
 | gateways.default.className | string | `"giantswarm-default"` |  |
 | gateways.default.clientTrafficPolicy | object | `{}` |  |
 | gateways.default.dnsName | string | `"gateway"` |  |
@@ -44,6 +48,7 @@ Default configuration for Envoy Gateway
 | gateways.default.envoyProxy.envoyPDB | object | `{}` |  |
 | gateways.default.envoyProxy.envoyService | object | `{}` |  |
 | gateways.default.envoyProxy.envoyServiceAccount | object | `{}` |  |
+| gateways.default.envoyProxy.mergeType | string | `"StrategicMerge"` |  |
 | gateways.default.errorPages | object | `{}` |  |
 | gateways.default.listeners.http.allowedRoutes.namespaces.from | string | `"All"` |  |
 | gateways.default.listeners.http.httpsRedirectEnabled | bool | `false` |  |

--- a/helm/gateway-api-config/templates/_helpers.tpl
+++ b/helm/gateway-api-config/templates/_helpers.tpl
@@ -177,4 +177,7 @@ mergeGateways: {{ .mergeGateways }}
 shutdown:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- if .mergeType }}
+mergeType: {{ .mergeType }}
+{{- end }}
 {{- end }}

--- a/helm/gateway-api-config/templates/gateway/envoyproxy.yaml
+++ b/helm/gateway-api-config/templates/gateway/envoyproxy.yaml
@@ -1,12 +1,9 @@
+{{/*
+Gateway-specific EnvoyProxy defaults. Intentionally empty: base defaults (HPA, PDB, image)
+live on the GatewayClass EnvoyProxy and are inherited via mergeType: StrategicMerge. This block
+is kept as a placeholder for future gateway-specific defaults.
+*/}}
 {{- define "gatewayEnvoyProxyValuesDefault" }}
-envoyPDB:
-  maxUnavailable: "25%"
-envoyHpa:
-  minReplicas: 2
-  maxReplicas: 10
-envoyDeployment:
-  container:
-    imageRepository: gsoci.azurecr.io/giantswarm/envoy
 {{- end }}
 
 {{- range $i, $gateway := .Values.gateways }}
@@ -24,6 +21,9 @@ envoyDeployment:
 {{- $shutdownDefaults := (include "gateway.shutdownDefaults" (dict "provider" $.Values.provider "gateway" $gateway)) | fromYaml -}}
 {{- if $shutdownDefaults -}}
 {{- $_ := set $envoyProxyValues "shutdown" (mergeOverwrite $shutdownDefaults (deepCopy (default dict $envoyProxyValues.shutdown))) -}}
+{{- end }}
+{{- if not $envoyProxyValues.mergeType -}}
+{{- $_ := set $envoyProxyValues "mergeType" "StrategicMerge" -}}
 {{- end }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -33,6 +33,10 @@ gatewayClasses:
       existingConfigMapName: ""
     envoyProxy:
       enabled: true
+      # Controls how this GatewayClass-level EnvoyProxy merges with EnvoyGateway defaults
+      # (hierarchy: EnvoyGateway defaults < GatewayClass < Gateway). Leave unset to fully
+      # replace EnvoyGateway defaults; set to StrategicMerge or JSONMerge to extend them.
+      mergeType: ""
       envoyDeployment: {}
       envoyService: {}
       envoyHpa: {}
@@ -108,6 +112,12 @@ gateways:
     errorPages: {}
     envoyProxy:
       enabled: true
+      # Controls how this gateway-level EnvoyProxy merges onto the GatewayClass-level one
+      # (hierarchy: EnvoyGateway defaults < GatewayClass < Gateway). StrategicMerge lets the
+      # gateway inherit GatewayClass base defaults (HPA, PDB, image) and only override deltas.
+      # A gateway referencing a className not managed by this chart will not inherit those
+      # base defaults. Defaults to StrategicMerge when left empty.
+      mergeType: StrategicMerge
       envoyDeployment: {}
       envoyService: {}
       envoyHpa: {}

--- a/tests/e2e/suites/basic/gateway_test.go
+++ b/tests/e2e/suites/basic/gateway_test.go
@@ -89,47 +89,68 @@ func gatewayGatewayTests() {
 		Should(BeTrue())
 }
 
-// gatewayEnvoyProxyTests confirms EnvoyProxy is configured with Giant Swarm's image registry,
-// correct HPA autoscaling bounds (2-10 replicas), and PDB disruption budget to ensure availability during updates.
+// gatewayEnvoyProxyTests confirms the base defaults (Giant Swarm image registry, HPA bounds 2-10,
+// PDB disruption budget) live on the GatewayClass-level EnvoyProxy, and that the gateway-level
+// EnvoyProxy is configured with mergeType: StrategicMerge so it inherits those defaults instead of
+// replacing them.
 func gatewayEnvoyProxyTests() {
 	wcName := state.GetCluster().Name
 	wcClient, _ := state.GetFramework().WC(wcName)
 
-	By("checking EnvoyProxy gateway-giantswarm-default exists in envoy-gateway-system")
-	envoyProxy := &unstructured.Unstructured{}
-	envoyProxy.SetGroupVersionKind(schema.GroupVersionKind{
+	envoyProxyGVK := schema.GroupVersionKind{
 		Group:   "gateway.envoyproxy.io",
 		Version: "v1alpha1",
 		Kind:    "EnvoyProxy",
-	})
+	}
+
+	By("checking EnvoyProxy gatewayclass-giantswarm-default exists in envoy-gateway-system")
+	classProxy := &unstructured.Unstructured{}
+	classProxy.SetGroupVersionKind(envoyProxyGVK)
 	Eventually(func() error {
 		return wcClient.Get(state.GetContext(), cr.ObjectKey{
-			Name:      "gateway-giantswarm-default",
+			Name:      "gatewayclass-giantswarm-default",
 			Namespace: "envoy-gateway-system",
-		}, envoyProxy)
+		}, classProxy)
 	}).
 		WithTimeout(5 * time.Minute).
 		WithPolling(5 * time.Second).
 		Should(Succeed())
 
-	By("checking EnvoyProxy imageRepository starts with gsoci.azurecr.io/giantswarm/envoy")
-	envoySpec := envoyProxy.Object["spec"].(map[string]any)
-	provider := envoySpec["provider"].(map[string]any)
-	kubernetes := provider["kubernetes"].(map[string]any)
-	envoyDeployment := kubernetes["envoyDeployment"].(map[string]any)
+	By("checking GatewayClass EnvoyProxy imageRepository starts with gsoci.azurecr.io/giantswarm/envoy")
+	classSpec := classProxy.Object["spec"].(map[string]any)
+	classProvider := classSpec["provider"].(map[string]any)
+	classKubernetes := classProvider["kubernetes"].(map[string]any)
+	envoyDeployment := classKubernetes["envoyDeployment"].(map[string]any)
 	container := envoyDeployment["container"].(map[string]any)
 	imageRepo := container["imageRepository"].(string)
 	Expect(strings.HasPrefix(imageRepo, "gsoci.azurecr.io/giantswarm/envoy")).To(BeTrue(),
 		"expected imageRepository to start with gsoci.azurecr.io/giantswarm/envoy, got: %s", imageRepo)
 
-	By("checking EnvoyProxy HPA minReplicas=2, maxReplicas=10")
-	hpa := kubernetes["envoyHpa"].(map[string]any)
+	By("checking GatewayClass EnvoyProxy HPA minReplicas=2, maxReplicas=10")
+	hpa := classKubernetes["envoyHpa"].(map[string]any)
 	Expect(hpa["minReplicas"]).To(BeEquivalentTo(2))
 	Expect(hpa["maxReplicas"]).To(BeEquivalentTo(10))
 
-	By("checking EnvoyProxy PDB maxUnavailable=25%")
-	pdb := kubernetes["envoyPDB"].(map[string]any)
+	By("checking GatewayClass EnvoyProxy PDB maxUnavailable=25%")
+	pdb := classKubernetes["envoyPDB"].(map[string]any)
 	Expect(pdb["maxUnavailable"]).To(Equal("25%"))
+
+	By("checking EnvoyProxy gateway-giantswarm-default exists in envoy-gateway-system")
+	gatewayProxy := &unstructured.Unstructured{}
+	gatewayProxy.SetGroupVersionKind(envoyProxyGVK)
+	Eventually(func() error {
+		return wcClient.Get(state.GetContext(), cr.ObjectKey{
+			Name:      "gateway-giantswarm-default",
+			Namespace: "envoy-gateway-system",
+		}, gatewayProxy)
+	}).
+		WithTimeout(5 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(Succeed())
+
+	By("checking gateway-level EnvoyProxy mergeType=StrategicMerge")
+	gatewaySpec := gatewayProxy.Object["spec"].(map[string]any)
+	Expect(gatewaySpec["mergeType"]).To(Equal("StrategicMerge"))
 }
 
 // gatewayClientTrafficPolicyTests validates ClientTrafficPolicy correctly targets the gateway,


### PR DESCRIPTION
## What

Adopt the `EnvoyProxy.spec.mergeType` field (available since Envoy Gateway 1.8.1) to drive the GatewayClass → Gateway merge hierarchy instead of relying on the implicit `Replace` default.

- Set `mergeType: StrategicMerge` on the **gateway-level** `EnvoyProxy` so it layers *onto* the GatewayClass-level base instead of replacing it.
- Move the shared base defaults (HPA 2–10, PDB 25%, `gsoci.azurecr.io/giantswarm/envoy` image) to live **only** on the GatewayClass `EnvoyProxy`. The gateway-level resource now carries only gateway-specific config (`envoyService`/NLB annotations, `shutdown`) plus user overrides.
- `mergeType` is now configurable per gateway and per GatewayClass via `envoyProxy.mergeType` (gateway defaults to `StrategicMerge`; GatewayClass defaults to unset/`Replace`).
- Kept `gatewayEnvoyProxyValuesDefault` as an empty placeholder for future gateway-specific defaults.

## Why

Previously both `EnvoyProxy` resources duplicated the same base defaults, because with `mergeType` unset Envoy Gateway *fully replaces* the GatewayClass config with the Gateway config. StrategicMerge lets us use the upstream hierarchy (`EnvoyGateway defaults < GatewayClass < Gateway`) as intended and removes the duplication.

## Note

A gateway referencing a `className` not managed by this chart will not inherit the GatewayClass base defaults — documented in `values.yaml`.

## Verification

- `helm template` (default + `provider=capa`): gateway `EnvoyProxy` renders `mergeType: StrategicMerge` + `envoyService`/`shutdown` only; GatewayClass `EnvoyProxy` keeps HPA/PDB/image. User override (`envoyProxy.envoyHpa.minReplicas`) renders at the gateway level and merges server-side.
- `helm lint` passes.
- E2E (`tests/e2e/suites/basic/deployment_test.go`) asserts on the **runtime** result (HPA/PDB existence, `gsoci` image, service annotations) — validating the server-side strategic merge. Pending a CAPA cluster run.