### PR TITLE
feat(backendtrafficpolicy): support configurable spec fields per gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a per-gateway `backendTrafficPolicy` value whose keys pass through to the `BackendTrafficPolicy` spec (e.g. `circuitBreaker`, `rateLimit`, `retry`). It is merged into the same policy as the error-pages `responseOverride`, since Envoy Gateway allows only one `BackendTrafficPolicy` per Gateway.
+
 ### Changed
 
+- Rename the per-gateway `BackendTrafficPolicy` from `gateway-{name}-error-pages` to `gateway-{name}`, as it now carries more than error pages. The error-pages `ConfigMap` keeps its `gateway-{name}-error-pages` name. On upgrade the old policy is replaced.
 - Set `mergeType: StrategicMerge` on the gateway-level `EnvoyProxy` so it inherits the GatewayClass-level base defaults (HPA, PDB, image) instead of replacing them. Base defaults are no longer duplicated on the gateway-level `EnvoyProxy`; it now carries only gateway-specific config (`envoyService`, `shutdown`) plus user overrides. `mergeType` is configurable per gateway and per GatewayClass via `envoyProxy.mergeType`.
 
 ## [1.10.1] - 2026-05-05

--- a/helm/gateway-api-config/README.md
+++ b/helm/gateway-api-config/README.md
@@ -38,6 +38,7 @@ Default configuration for Envoy Gateway
 | gateways.default.allowedListeners.enabled | bool | `false` |  |
 | gateways.default.allowedListeners.namespaces.from | string | `"All"` |  |
 | gateways.default.allowedListeners.namespaces.selector | object | `{}` |  |
+| gateways.default.backendTrafficPolicy | object | `{}` |  |
 | gateways.default.className | string | `"giantswarm-default"` |  |
 | gateways.default.clientTrafficPolicy | object | `{}` |  |
 | gateways.default.dnsName | string | `"gateway"` |  |

--- a/helm/gateway-api-config/templates/gateway/backendtrafficpolicy.yaml
+++ b/helm/gateway-api-config/templates/gateway/backendtrafficpolicy.yaml
@@ -7,12 +7,21 @@
 {{- end }}
 {{- end }}
 {{- $errorPages := include "errorPages.effective" (dict "class" $classErrorPages "gateway" $gateway.errorPages) | fromYaml }}
-{{- if $errorPages.enabled }}
+{{- /* Pass-through BackendTrafficPolicy spec fields (circuitBreaker, rateLimit, retry, ...). */}}
+{{- $btp := $gateway.backendTrafficPolicy | default dict }}
+{{- $spec := omit $btp "enabled" }}
+{{- /* Render a single policy when error pages are enabled or extra spec fields are set,
+       unless explicitly disabled via backendTrafficPolicy.enabled: false. */}}
+{{- $shouldRender := or $errorPages.enabled (gt (len $spec) 0) }}
+{{- if and (hasKey $btp "enabled") (not $btp.enabled) }}
+{{- $shouldRender = false }}
+{{- end }}
+{{- if $shouldRender }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
-  name: gateway-{{ $gateway.name }}-error-pages
+  name: gateway-{{ $gateway.name }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
@@ -21,6 +30,10 @@ spec:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: {{ $gateway.name }}
+  {{- with $spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- if $errorPages.enabled }}
   responseOverride:
     - match:
         statusCodes:
@@ -47,6 +60,7 @@ spec:
             {{- else }}
             name: gateway-{{ $gateway.name }}-error-pages
             {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/gateway-api-config/values.schema.json
+++ b/helm/gateway-api-config/values.schema.json
@@ -108,6 +108,9 @@
                                 }
                             }
                         },
+                        "backendTrafficPolicy": {
+                            "type": "object"
+                        },
                         "className": {
                             "type": "string"
                         },

--- a/helm/gateway-api-config/values.yaml
+++ b/helm/gateway-api-config/values.yaml
@@ -110,6 +110,21 @@ gateways:
     # Per-gateway error pages override gatewayClass errorPages settings.
     # Omit fields to inherit from gatewayClass config.
     errorPages: {}
+    # BackendTrafficPolicy configures Envoy Gateway backend traffic settings for
+    # this gateway. When omitted, a policy is created only if error pages are
+    # enabled (see errorPages). Any keys set here are passed directly to the
+    # BackendTrafficPolicy spec and are merged into the same policy as the error
+    # pages responseOverride (Envoy Gateway allows only one policy per Gateway).
+    # Set enabled: false to suppress the policy even when error pages are enabled.
+    # Available fields (see kubectl explain backendtrafficpolicy.spec): circuitBreaker,
+    # rateLimit, retry, loadBalancer, healthCheck, timeout, ...
+    # Example:
+    #   backendTrafficPolicy:
+    #     circuitBreaker:
+    #       maxConnections: 1024
+    #       maxPendingRequests: 1024
+    #       maxParallelRequests: 1024
+    backendTrafficPolicy: {}
     envoyProxy:
       enabled: true
       # Controls how this gateway-level EnvoyProxy merges onto the GatewayClass-level one

--- a/tests/e2e/suites/basic/bundle_values.yaml
+++ b/tests/e2e/suites/basic/bundle_values.yaml
@@ -23,6 +23,11 @@ apps:
               dnsName: ingress
               errorPages:
                 body: "<html><body><h1>Giant Swarm - Service Unavailable</h1></body></html>"
+              backendTrafficPolicy:
+                circuitBreaker:
+                  maxConnections: 1024
+                  maxPendingRequests: 1024
+                  maxParallelRequests: 1024
               listeners:
                 http:
                   httpsRedirectEnabled: true

--- a/tests/e2e/suites/basic/gateway_test.go
+++ b/tests/e2e/suites/basic/gateway_test.go
@@ -193,13 +193,14 @@ func gatewayClientTrafficPolicyTests() {
 	Expect(healthCheck["path"]).To(Equal("/healthz"))
 }
 
-// gatewayBackendTrafficPolicyTests validates BackendTrafficPolicy is configured to return
-// custom error pages for 5xx status codes, targeting the default gateway.
+// gatewayBackendTrafficPolicyTests validates the BackendTrafficPolicy is configured to return
+// custom error pages for 5xx status codes and carries the configured circuit breaker,
+// targeting the default gateway.
 func gatewayBackendTrafficPolicyTests() {
 	wcName := state.GetCluster().Name
 	wcClient, _ := state.GetFramework().WC(wcName)
 
-	By("checking BackendTrafficPolicy gateway-giantswarm-default-error-pages exists in envoy-gateway-system")
+	By("checking BackendTrafficPolicy gateway-giantswarm-default exists in envoy-gateway-system")
 	btp := &unstructured.Unstructured{}
 	btp.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "gateway.envoyproxy.io",
@@ -208,7 +209,7 @@ func gatewayBackendTrafficPolicyTests() {
 	})
 	Eventually(func() error {
 		return wcClient.Get(state.GetContext(), cr.ObjectKey{
-			Name:      "gateway-giantswarm-default-error-pages",
+			Name:      "gateway-giantswarm-default",
 			Namespace: "envoy-gateway-system",
 		}, btp)
 	}).
@@ -223,6 +224,12 @@ func gatewayBackendTrafficPolicyTests() {
 	targetRef := targetRefs[0].(map[string]any)
 	Expect(targetRef["name"]).To(Equal("giantswarm-default"))
 	Expect(targetRef["kind"]).To(Equal("Gateway"))
+
+	By("checking BackendTrafficPolicy carries the configured circuitBreaker")
+	circuitBreaker := btpSpec["circuitBreaker"].(map[string]any)
+	Expect(circuitBreaker["maxConnections"]).To(BeEquivalentTo(1024))
+	Expect(circuitBreaker["maxPendingRequests"]).To(BeEquivalentTo(1024))
+	Expect(circuitBreaker["maxParallelRequests"]).To(BeEquivalentTo(1024))
 
 	By("checking BackendTrafficPolicy responseOverride has Value and Range status codes")
 	responseOverride := btpSpec["responseOverride"].([]any)
@@ -260,7 +267,7 @@ func gatewayBackendTrafficPolicyTests() {
 	By("checking BackendTrafficPolicy is Accepted")
 	Eventually(func() (bool, error) {
 		if err := wcClient.Get(state.GetContext(), cr.ObjectKey{
-			Name:      "gateway-giantswarm-default-error-pages",
+			Name:      "gateway-giantswarm-default",
 			Namespace: "envoy-gateway-system",
 		}, btp); err != nil {
 			return false, err


### PR DESCRIPTION
## What

Makes the per-gateway `BackendTrafficPolicy` configurable beyond error pages. Adds a general pass-through `backendTrafficPolicy` value (mirroring the existing `clientTrafficPolicy` pattern) so gateways can set `circuitBreaker`, `rateLimit`, `retry`, `loadBalancer`, `healthCheck`, `timeout`, etc.

## Why

Until now the chart created a `BackendTrafficPolicy` solely to serve error pages (`responseOverride`). There was no way to configure other backend traffic settings such as circuit breakers.

Envoy Gateway allows **only one** `BackendTrafficPolicy` per target Gateway, so the new fields are merged into the **same** resource as the error-pages `responseOverride` rather than a second policy.

## Changes

- `templates/gateway/backendtrafficpolicy.yaml`: emit a single policy per gateway that merges pass-through spec fields with the error-pages `responseOverride`. Renders when error pages are enabled **or** extra fields are set; `backendTrafficPolicy.enabled: false` suppresses it.
- Rename the resource `gateway-{name}-error-pages` → `gateway-{name}` (the error-pages `ConfigMap` keeps its name). **On upgrade the old policy is replaced.**
- `values.yaml`, `values.schema.json`, `README.md`: add and document the new `backendTrafficPolicy` value.
- E2E: rename the looked-up resource and assert `circuitBreaker` renders alongside the error pages.
- `CHANGELOG.md`: `Added` + `Changed` entries under `[Unreleased]`.

## Verification

- `helm template` checked for: defaults (no policy), circuitBreaker-only, both (single merged policy), and explicit disable.
- `helm lint`, `values.schema.json` validity, and e2e `go build`/`go vet` all pass.
- Live-cluster e2e and `make lint-chart` (ct in Docker) to run in CI.