### PR TITLE
fix(envoyproxy): align NLB drain timers to prevent 520 errors on node disruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - For CAPA gateways using an AWS NLB, set `karpenter.sh/do-not-disrupt: "true"` on the envoy proxy pod template to reduce voluntary Karpenter churn, and patch `terminationGracePeriodSeconds: 240` on the proxy Deployment so it stays above the drain timeout.
+- For CAPA gateways using an AWS NLB, add a preferred pod anti-affinity (`topologyKey: kubernetes.io/hostname`) on the proxy pod template so the proxy pods spread one-per-node, ensuring each NLB instance target maps to a single envoy.
 
 ## [1.11.0] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Align the AWS NLB drain timers with the envoy graceful shutdown so the node always outlives the NLB connection drain, fixing Cloudflare 520 errors on node disruption (e.g. Karpenter). The gateway-level `EnvoyProxy` now sets `shutdown.minDrainDuration: 150s` and `shutdown.drainTimeout: 170s` (was 60s/180s), lowers the service `target_health_state.unhealthy.draining_interval_seconds` to `120` (was 200), and speeds up unhealthy-node detection via `aws-load-balancer-healthcheck-interval: 10` and `aws-load-balancer-healthcheck-unhealthy-threshold: 2`.
+
+### Added
+
+- For CAPA gateways using an AWS NLB, set `karpenter.sh/do-not-disrupt: "true"` on the envoy proxy pod template to reduce voluntary Karpenter churn, and patch `terminationGracePeriodSeconds: 240` on the proxy Deployment so it stays above the drain timeout.
+
 ## [1.11.0] - 2026-06-17
 
 ### Added

--- a/helm/gateway-api-config/templates/_helpers.tpl
+++ b/helm/gateway-api-config/templates/_helpers.tpl
@@ -43,13 +43,16 @@ Gateway Service annotations
 {{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-healthcheck-port" "http-80" }}
 {{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-healthcheck-path" "/healthz" }}
 {{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold" "2" }}
+{{- /* Detect an unhealthy node quickly so the NLB drain starts well before envoy exits */}}
+{{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval" "10" }}
+{{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold" "2" }}
 
 {{- /* Make LB public by default */}}
 {{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-scheme" "internet-facing" }}
 
 {{- /* Configure attributes */}}
 {{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-attributes" "load_balancing.cross_zone.enabled=true" }}
-{{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes" "target_health_state.unhealthy.connection_termination.enabled=false,target_health_state.unhealthy.draining_interval_seconds=200,preserve_client_ip.enabled=false" }}
+{{- $_ := set $annotations "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes" "target_health_state.unhealthy.connection_termination.enabled=false,target_health_state.unhealthy.draining_interval_seconds=120,preserve_client_ip.enabled=false" }}
 {{- end }}
 
 {{- $annotations = mergeOverwrite $annotations (deepCopy (default dict $service.annotations)) }}
@@ -103,11 +106,34 @@ Gateway Shutdown defaults - computes provider-specific shutdown configuration
 {{- define "gateway.shutdownDefaults" -}}
 {{- $shutdown := dict }}
 {{- /* Set defaults for AWS NLBs */}}
+{{- /*
+  Drain timers are aligned so the node always outlives the NLB connection drain.
+  With healthcheck detection (~20s) + draining_interval_seconds (120s) ~= 140s, a
+  minDrainDuration of 150s keeps envoy (and therefore the node) alive until all
+  in-flight NLB flows have moved off the node, avoiding RST/520 on node disruption.
+*/}}
 {{- if and (eq .provider "capa") (.gateway.provider.aws.useNetworkLoadBalancer) }}
-{{- $_ := set $shutdown "drainTimeout" "180s" }}
-{{- $_ := set $shutdown "minDrainDuration" "60s" }}
+{{- $_ := set $shutdown "drainTimeout" "170s" }}
+{{- $_ := set $shutdown "minDrainDuration" "150s" }}
 {{- end }}
 {{- $shutdown | toYaml }}
+{{- end }}
+
+{{/*
+Gateway EnvoyDeployment defaults - computes provider-specific deployment configuration.
+For AWS NLBs this reduces voluntary Karpenter churn on gateway nodes and ensures the
+pod's terminationGracePeriodSeconds stays above the drain timeout.
+*/}}
+{{- define "gateway.envoyDeploymentDefaults" -}}
+{{- $envoyDeployment := dict }}
+{{- if and (eq .provider "capa") (.gateway.provider.aws.useNetworkLoadBalancer) }}
+{{- /* Stop Karpenter consolidation/drift/expiry from churning gateway nodes */}}
+{{- $_ := set $envoyDeployment "pod" (dict "annotations" (dict "karpenter.sh/do-not-disrupt" "true")) }}
+{{- /* terminationGracePeriodSeconds has no dedicated field on EnvoyProxy, so patch it.
+       It must stay above shutdown.drainTimeout (170s). */}}
+{{- $_ := set $envoyDeployment "patch" (dict "type" "StrategicMerge" "value" (dict "spec" (dict "template" (dict "spec" (dict "terminationGracePeriodSeconds" 240))))) }}
+{{- end }}
+{{- $envoyDeployment | toYaml }}
 {{- end }}
 
 {{/*

--- a/helm/gateway-api-config/templates/_helpers.tpl
+++ b/helm/gateway-api-config/templates/_helpers.tpl
@@ -121,14 +121,27 @@ Gateway Shutdown defaults - computes provider-specific shutdown configuration
 
 {{/*
 Gateway EnvoyDeployment defaults - computes provider-specific deployment configuration.
-For AWS NLBs this reduces voluntary Karpenter churn on gateway nodes and ensures the
-pod's terminationGracePeriodSeconds stays above the drain timeout.
+For AWS NLBs this reduces voluntary Karpenter churn on gateway nodes, ensures the
+pod's terminationGracePeriodSeconds stays above the drain timeout, and spreads the
+proxy pods one-per-node so each NLB instance target maps to a single envoy.
 */}}
 {{- define "gateway.envoyDeploymentDefaults" -}}
 {{- $envoyDeployment := dict }}
 {{- if and (eq .provider "capa") (.gateway.provider.aws.useNetworkLoadBalancer) }}
+{{- $pod := dict }}
 {{- /* Stop Karpenter consolidation/drift/expiry from churning gateway nodes */}}
-{{- $_ := set $envoyDeployment "pod" (dict "annotations" (dict "karpenter.sh/do-not-disrupt" "true")) }}
+{{- $_ := set $pod "annotations" (dict "karpenter.sh/do-not-disrupt" "true") }}
+{{- /* Prefer one proxy pod per node so each NLB instance target maps to a single
+       envoy, improving NLB health-checking and traffic distribution. Selects pods by
+       the owning-gateway labels Envoy Gateway stamps on the proxy pods. */}}
+{{- $podAffinityTerm := dict
+      "labelSelector" (dict "matchExpressions" (list
+        (dict "key" "gateway.envoyproxy.io/owning-gateway-name" "operator" "In" "values" (list .gateway.name))
+        (dict "key" "gateway.envoyproxy.io/owning-gateway-namespace" "operator" "In" "values" (list .namespace))
+      ))
+      "topologyKey" "kubernetes.io/hostname" }}
+{{- $_ := set $pod "affinity" (dict "podAntiAffinity" (dict "preferredDuringSchedulingIgnoredDuringExecution" (list (dict "weight" 100 "podAffinityTerm" $podAffinityTerm)))) }}
+{{- $_ := set $envoyDeployment "pod" $pod }}
 {{- /* terminationGracePeriodSeconds has no dedicated field on EnvoyProxy, so patch it.
        It must stay above shutdown.drainTimeout (170s). */}}
 {{- $_ := set $envoyDeployment "patch" (dict "type" "StrategicMerge" "value" (dict "spec" (dict "template" (dict "spec" (dict "terminationGracePeriodSeconds" 240))))) }}

--- a/helm/gateway-api-config/templates/gateway/envoyproxy.yaml
+++ b/helm/gateway-api-config/templates/gateway/envoyproxy.yaml
@@ -22,6 +22,10 @@ is kept as a placeholder for future gateway-specific defaults.
 {{- if $shutdownDefaults -}}
 {{- $_ := set $envoyProxyValues "shutdown" (mergeOverwrite $shutdownDefaults (deepCopy (default dict $envoyProxyValues.shutdown))) -}}
 {{- end }}
+{{- $envoyDeploymentDefaults := (include "gateway.envoyDeploymentDefaults" (dict "provider" $.Values.provider "gateway" $gateway)) | fromYaml -}}
+{{- if $envoyDeploymentDefaults -}}
+{{- $_ := set $envoyProxyValues "envoyDeployment" (mergeOverwrite $envoyDeploymentDefaults (deepCopy (default dict $envoyProxyValues.envoyDeployment))) -}}
+{{- end }}
 {{- if not $envoyProxyValues.mergeType -}}
 {{- $_ := set $envoyProxyValues "mergeType" "StrategicMerge" -}}
 {{- end }}

--- a/helm/gateway-api-config/templates/gateway/envoyproxy.yaml
+++ b/helm/gateway-api-config/templates/gateway/envoyproxy.yaml
@@ -22,7 +22,7 @@ is kept as a placeholder for future gateway-specific defaults.
 {{- if $shutdownDefaults -}}
 {{- $_ := set $envoyProxyValues "shutdown" (mergeOverwrite $shutdownDefaults (deepCopy (default dict $envoyProxyValues.shutdown))) -}}
 {{- end }}
-{{- $envoyDeploymentDefaults := (include "gateway.envoyDeploymentDefaults" (dict "provider" $.Values.provider "gateway" $gateway)) | fromYaml -}}
+{{- $envoyDeploymentDefaults := (include "gateway.envoyDeploymentDefaults" (dict "provider" $.Values.provider "gateway" $gateway "namespace" $.Release.Namespace)) | fromYaml -}}
 {{- if $envoyDeploymentDefaults -}}
 {{- $_ := set $envoyProxyValues "envoyDeployment" (mergeOverwrite $envoyDeploymentDefaults (deepCopy (default dict $envoyProxyValues.envoyDeployment))) -}}
 {{- end }}


### PR DESCRIPTION
## What

Align the AWS NLB drain timers with the envoy graceful shutdown so a gateway node always outlives the NLB connection drain.

## Why

When a node running an envoy proxy pod is disrupted (e.g. by Karpenter), Cloudflare sees a spike of **520 errors**. The NLB keeps in-flight flows pinned to the node for up to `draining_interval_seconds` (200s) while envoy only kept the node alive for 60–180s, so the flows got blackholed → RST → 520. The timers were inverted.

Fixes giantswarm/giantswarm#36939

## Changes (CAPA + AWS NLB path only; other providers unaffected)

- `shutdown.minDrainDuration` 60s → **150s** (the key fix), `shutdown.drainTimeout` 180s → **170s**
- service `target_health_state.unhealthy.draining_interval_seconds` 200 → **120**
- faster unhealthy-node detection: `aws-load-balancer-healthcheck-interval: 10`, `aws-load-balancer-healthcheck-unhealthy-threshold: 2`
- `karpenter.sh/do-not-disrupt: "true"` on the proxy pod template to reduce voluntary churn
- patch `terminationGracePeriodSeconds: 240` on the proxy Deployment (no dedicated EnvoyProxy field), kept above the drain timeout

Resulting invariant: detection (~20s) + NLB drain (120s) ≈ 140s < minDrainDuration (150s) < drainTimeout (170s) < terminationGracePeriodSeconds (240s).

## Out of scope (noted in the issue)

- NodePool `terminationGracePeriod` and on-demand-vs-spot preference are cluster/infra config, not part of this chart.
- `--drain-strategy immediate` / `--drain-time-s` are derived by Envoy Gateway from the `shutdown` block, not separately configurable on the CRD.

## Testing

- `helm template` renders valid output for both the CAPA+NLB and non-NLB paths.
- Verified user overrides still merge with the new defaults taking lower precedence.
