### PR TITLE
feat(envoyproxy): set giantswarm-critical priorityClass on proxy pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set `priorityClassName: giantswarm-critical` on the envoy proxy pods via the GatewayClass-level `EnvoyProxy` (inherited by all gateways), so the proxies are scheduled and protected as critical workloads.
+
 ## [1.11.1] - 2026-06-19
 
 ### Changed

--- a/helm/gateway-api-config/templates/gatewayclass/envoyproxy.yaml
+++ b/helm/gateway-api-config/templates/gatewayclass/envoyproxy.yaml
@@ -5,6 +5,8 @@ envoyHpa:
   minReplicas: 2
   maxReplicas: 10
 envoyDeployment:
+  pod:
+    priorityClassName: giantswarm-critical
   container:
     imageRepository: gsoci.azurecr.io/giantswarm/envoy
 {{- end }}

--- a/tests/e2e/suites/basic/deployment_test.go
+++ b/tests/e2e/suites/basic/deployment_test.go
@@ -124,6 +124,26 @@ func gatewayDeploymentTests() {
 		WithPolling(5 * time.Second).
 		Should(BeTrue())
 
+	By("checking envoy proxy pods use the giantswarm-critical priorityClassName")
+	Eventually(func() error {
+		proxyPods := &corev1.PodList{}
+		if err := wcClient.List(state.GetContext(), proxyPods, proxyPodsListOptions); err != nil {
+			return err
+		}
+		if len(proxyPods.Items) == 0 {
+			return fmt.Errorf("no proxy pods found")
+		}
+		for _, pod := range proxyPods.Items {
+			if pod.Spec.PriorityClassName != "giantswarm-critical" {
+				return fmt.Errorf("pod %s/%s has priorityClassName %q, expected giantswarm-critical", pod.Namespace, pod.Name, pod.Spec.PriorityClassName)
+			}
+		}
+		return nil
+	}).
+		WithTimeout(5 * time.Minute).
+		WithPolling(5 * time.Second).
+		Should(Succeed())
+
 	By("checking service has external-dns annotations for the default gateway")
 	Eventually(func() error {
 		svcList := &corev1.ServiceList{}


### PR DESCRIPTION
## What

Set `priorityClassName: giantswarm-critical` on the envoy proxy pods via the GatewayClass-level `EnvoyProxy` base defaults. Gateways inherit it through `mergeType: StrategicMerge`, so every gateway's proxy pods are scheduled and protected as critical workloads. It remains overridable per gateway/class via `envoyProxy.envoyDeployment.pod`.

## Changes

- `templates/gatewayclass/envoyproxy.yaml`: add `envoyDeployment.pod.priorityClassName: giantswarm-critical` to the base defaults.
- `tests/e2e/.../deployment_test.go`: assert proxy pods report the expected priorityClassName.
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Notes

This covers the data-plane proxy pods (this repo). The Envoy Gateway **controller** pods live in `envoy-gateway-app/` and are not covered here.

## Verification

- `helm template` renders the field on the GatewayClass `EnvoyProxy` (inherited, not duplicated on the gateway one).
- `helm lint` passes.
- e2e package builds.

Towards https://github.com/giantswarm/giantswarm/issues/36991